### PR TITLE
Remove the usage of 7z

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@ CLI tool for downloading subtitles from napiprojekt.pl, fork of [gabrys/napi.py]
 
 ## prerequisites
 - Python 3.6 or newer
-- `7z` executable available on PATH, can be installed:
-    - on Debian-based distros with `sudo apt-get install p7zip-full`
-    - on macOS with `brew install p7zip` using [homebrew](https://brew.sh/)
 
 ## installation
 - `pip install napi-py` for user-wide installation

--- a/napi/read_7z.py
+++ b/napi/read_7z.py
@@ -1,39 +1,14 @@
-from subprocess import Popen, PIPE
-from tempfile import NamedTemporaryFile
+from io import BytesIO
 from typing import Optional
+from py7zlib import Archive7z, ArchiveError
 
-TMP_FILE_SUFFIX = ".7z"
-TMP_FILE_PREFIX = "un7zip"
 NAPI_ARCHIVE_PASSWORD = "iBlm8NTigvru0Jr0"
-
-
-class Un7ZipError(Exception):
-    pass
-
-
-def un7zip(archive, password=None):
-    tmp_file = NamedTemporaryFile(prefix=TMP_FILE_PREFIX, suffix=TMP_FILE_SUFFIX)
-    tmp_file.write(archive)
-    tmp_file.flush()
-
-    cmd = ["7z", "x", "-y", "-so"]
-    if password is not None:
-        cmd += ["-p" + password]
-    cmd += [tmp_file.name]
-
-    sp = Popen(cmd, stdout=PIPE, stderr=PIPE)
-
-    content = sp.communicate()[0]
-
-    if sp.wait() != 0:
-        raise Un7ZipError("Downloaded archive with subtitles is broken!")
-
-    tmp_file.close()  # deletes the file
-    return content
 
 
 def un7zip_api_response(content_7z: bytes) -> Optional[bytes]:
     try:
-        return un7zip(content_7z, password=NAPI_ARCHIVE_PASSWORD)
-    except Un7ZipError:
+        buffer = BytesIO(content_7z)
+        archive = Archive7z(buffer, password=NAPI_ARCHIVE_PASSWORD)
+        return archive.getmember(0).read()
+    except ArchiveError:
         return None

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,12 @@ from distutils.core import setup
 from setuptools import find_packages
 
 REQUIREMENTS = [
+    "pylzma"
 ]
 
 REQUIREMENTS_DEV = [
     "mypy==0.*",
+    "pylzma",
     "pytest==6.*",
     "twine",
     "wheel==0.*"

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from distutils.core import setup
 from setuptools import find_packages
 
 REQUIREMENTS = [
-    "pylzma"
+    "pylzma==0.*"
 ]
 
 REQUIREMENTS_DEV = [
     "mypy==0.*",
-    "pylzma",
+    "pylzma==0.*",
     "pytest==6.*",
     "twine",
     "wheel==0.*"
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="napi-py",
-    version="1.1.1",
+    version="1.1.2",
     description="CLI tool for downloading subtitles from napiprojekt.pl",
     author="Mateusz Korzeniowski",
     author_email="emkor93@gmail.com",


### PR DESCRIPTION
Changelog:
- Refactored `un7zip_api_response` function to use external `pylzma` package in archive extraction process.
- Removed redundant `un7zip` function as well as imports.
- Updated `setup.py` with proper dependencies.
- Updated `README.md`